### PR TITLE
Added parsing of remote logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #.idea/
 .vscode/
 test.csv
+.netrc

--- a/.netrc
+++ b/.netrc
@@ -1,3 +1,0 @@
-machine example.com
-login my_username
-password my_password

--- a/.netrc
+++ b/.netrc
@@ -1,0 +1,3 @@
+machine example.com
+login my_username
+password my_password

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,6 @@ COPY . /opt/app-root/src
 
 RUN pip install -r requirements.txt
 
+ENV NETRC=/opt/app-root/src/.netrc
+
 CMD python3 analyze_csv.py 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,6 @@ FROM registry.access.redhat.com/ubi9/python-39:latest
 
 COPY . /opt/app-root/src
 
+RUN pip install -r requirements.txt
+
 CMD python3 analyze_csv.py 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM registry.access.redhat.com/ubi9/python-39:latest
 
-COPY . /opt/app-root/src
+COPY requirements.txt /opt/app-root/src
 
 RUN pip install -r requirements.txt
 
-ENV NETRC=/opt/app-root/src/.netrc
+COPY . /opt/app-root/src
 
 CMD python3 analyze_csv.py 

--- a/analyze_csv.py
+++ b/analyze_csv.py
@@ -2,20 +2,7 @@
 import csv
 import sys
 
-from models import ClusterVerifierRecord, OCMState, InFlightState, Outcome
-
-# test_dict = {
-#     'timestamp': "2023-07-26T01:22:03Z",
-#     'cid': "myfancyclusterid",
-#     'cname': "fancy-cluster",
-#     'ocm_state': "ready",
-#     'ocm_inflight_states': "[\"passed\",\"failed\"]",
-#     'found_verifier_s3_logs': "TRUE",
-#     'found_all_tests_passed': "FALSE",
-#     'found_egress_failures': "NULL",
-#     'log_download_url': "example.com/logs/dwYEaJQ0Og/"
-# }
-# print(vars(ClusterVerifierRecord.from_dict(test_dict)))
+from models import ClusterVerifierRecord, Outcome
 
 cvrs = {}
 with open(sys.argv[1], newline="", encoding="utf-8") as f:
@@ -39,6 +26,7 @@ for _, cvr in cvrs.items():
     except KeyError:
         outcomes[cvr.get_outcome()] = [cvr]
 
+# pylint: disable=consider-using-dict-items
 for oc in outcomes:
     print(f"{oc}: {len(outcomes[oc])}")
 
@@ -62,7 +50,8 @@ recall = tp / (tp + fn)
 specificity = tn / (tn + fp)
 
 print(
-    f"FDR: {fdr:.1%} | FPR: {fpr:.1%} | Precision: {precision:.1%} | Recall (sensitivity): {recall:.1%}"
+    f"FDR: {fdr:.1%} | FPR: {fpr:.1%} | Precision: {precision:.1%} | "
+    f"Recall (sensitivity): {recall:.1%}"
 )
 print(f"F1: {f1:.1%} | ACC: {acc:.1%} | Specificity: {specificity:.1%}")
 
@@ -70,7 +59,8 @@ print("False Positives")
 fp_endpoints = {}
 for cvr in outcomes[Outcome.FALSE_POSITIVE]:
     print(
-        f"{cvr.log_download_url} {cvr.is_hostedcluster()}: {repr(cvr)} {repr(cvr.get_egress_failures())}"
+        f"{cvr.log_download_url} {cvr.is_hostedcluster()}: {repr(cvr)}"
+        f"{repr(cvr.get_egress_failures())}"
     )
     for ep in cvr.get_egress_failures():
         try:

--- a/analyze_csv.py
+++ b/analyze_csv.py
@@ -65,4 +65,4 @@ print(f"F1: {f1:.1%} | ACC: {acc:.1%} | Specificity: {specificity:.1%}")
 
 print("False Positives")
 for cvr in outcomes[Outcome.FALSE_POSITIVE]:
-    print(f"{cvr.log_download_url} : {repr(cvr)}")
+    print(f"{cvr.log_download_url} : {repr(cvr)} {repr(cvr.get_egress_failures())}")

--- a/analyze_csv.py
+++ b/analyze_csv.py
@@ -17,7 +17,6 @@ from models import ClusterVerifierRecord, OCMState, InFlightState, Outcome
 # }
 # print(vars(ClusterVerifierRecord.from_dict(test_dict)))
 
-
 cvrs = {}
 with open(sys.argv[1], newline="", encoding="utf-8") as f:
     reader = csv.DictReader(f)
@@ -64,5 +63,13 @@ print(
 print(f"F1: {f1:.1%} | ACC: {acc:.1%} | Specificity: {specificity:.1%}")
 
 print("False Positives")
+fp_endpoints = {}
 for cvr in outcomes[Outcome.FALSE_POSITIVE]:
     print(f"{cvr.log_download_url} : {repr(cvr)} {repr(cvr.get_egress_failures())}")
+    for ep in cvr.get_egress_failures():
+        try:
+            fp_endpoints[ep] += 1
+        except KeyError:
+            fp_endpoints[ep] = 1
+
+print(repr(fp_endpoints))

--- a/analyze_csv.py
+++ b/analyze_csv.py
@@ -49,6 +49,10 @@ tn = len(outcomes[Outcome.TRUE_NEGATIVE])
 fn = len(outcomes[Outcome.FALSE_NEGATIVE])
 fp = len(outcomes[Outcome.FALSE_POSITIVE])
 
+print(
+    f"True Negatives,{tn}\nFalse Negatives,{fn}\nTrue Positives,{tp}\nFalse Positives,{fp}"
+)
+
 fdr = fp / (fp + tp)
 fpr = fp / (fp + tn)
 f1 = (2 * tp) / (2 * tp + fp + fn)
@@ -65,7 +69,9 @@ print(f"F1: {f1:.1%} | ACC: {acc:.1%} | Specificity: {specificity:.1%}")
 print("False Positives")
 fp_endpoints = {}
 for cvr in outcomes[Outcome.FALSE_POSITIVE]:
-    print(f"{cvr.log_download_url} : {repr(cvr)} {repr(cvr.get_egress_failures())}")
+    print(
+        f"{cvr.log_download_url} {cvr.is_hostedcluster()}: {repr(cvr)} {repr(cvr.get_egress_failures())}"
+    )
     for ep in cvr.get_egress_failures():
         try:
             fp_endpoints[ep] += 1

--- a/models.py
+++ b/models.py
@@ -104,6 +104,9 @@ class ClusterVerifierRecord:
         # egress_failures will keep track of the unreachable egress endpoints
         self.__egress_failures = None
 
+        # hostedcluster will keep track of this cluster's hypershift status
+        self.__hostedcluster = None
+
         # reached_states keeps track of all states in which we've seen this cluster
         self.reached_states = set()
         if self.ocm_state is not None:
@@ -169,6 +172,20 @@ class ClusterVerifierRecord:
             # Cache the result
             self.__egress_failures = egress_failures
         return self.__egress_failures
+
+    def is_hostedcluster(self) -> bool:
+        """
+        Parses the OCM description file stored in log_download_url and returns True if
+        this cluster is an HCP/HyperShift HostedCluster (i.e. "hypershift.enabled")
+        """
+        if self.__hostedcluster is None:
+            desc = requests.get(
+                self.log_download_url + "desc.json",
+                timeout=5,
+                auth=self.remote_log_auth,
+            ).json()
+            self.__hostedcluster = bool(desc["hypershift"]["enabled"])
+        return self.__hostedcluster
 
     def __add__(self, other):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+htmllistparse==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 htmllistparse==0.6.1
+requests==2.31.0
+beautifulsoup4==4.12.2
+html5lib==1.1

--- a/settings.py
+++ b/settings.py
@@ -8,9 +8,25 @@ REMOTE_LOG_FILE_NAME = "osd-network-verifier-logs.txt"
 
 # Regular expression to use for capturing failed egress endpoints (should have a single
 # capturing group)
-REMOTE_LOG_REGEX_PATTERN = r"egressURL error\: ([\w\-\.]+\:\d+)\n"
+REMOTE_LOG_EGRESS_REGEX_PATTERN = r"egressURL error\: ([\w\-\.]+\:\d+)\n"
+
+# Regular expression to use for capturing other runtime errors (should have a single
+# capturing group)
+REMOTE_LOG_ERROR_REGEX_PATTERN = (
+    r"network verifier error:\s*(exceeded max wait time for \w* waiter"
+    r"|missing required permission [\w\d]*:[\w\d]*"
+    r"|waiter state transitioned to Failure"
+    r"|timed out waiting for the condition"
+    r"|unable to cleanup [\w\s]*"
+    r"|error performing [\w\d]*:[\w\d]*).*[\n$]"
+)
 
 # Set of egress endpoints that, if seen, should convert a false positive into a true
 # positive. For example, we can assume that a cluster that blocks its Splunk forwarding
 # URL will be considered "failed" even if OCM reports it as "ready"
-FORCE_FAILURE_ENDPOINTS = set(["inputs1.osdsecuritylogs.splunkcloud.com:9997"])
+FORCE_FAILURE_ENDPOINTS = set(
+    [
+        "inputs1.osdsecuritylogs.splunkcloud.com:9997",
+        "http-inputs-osdsecuritylogs.splunkcloud.com:443",
+    ]
+)

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,16 @@
 """'CSV Analysis Python Script' settings. Configure these before running'"""
 
+# Username and password for remote log HTTP server. Set to None if no auth needed
 REMOTE_LOG_AUTH = ("username", "password")
 
+# Name of the log file to parse for egress failures
 REMOTE_LOG_FILE_NAME = "osd-network-verifier-logs.txt"
+
+# Regular expression to use for capturing failed egress endpoints (should have a single
+# capturing group)
 REMOTE_LOG_REGEX_PATTERN = r"egressURL error\: ([\w\-\.]+\:\d+)\n"
+
+# Set of egress endpoints that, if seen, should convert a false positive into a true
+# positive. For example, we can assume that a cluster that blocks its Splunk forwarding
+# URL will be considered "failed" even if OCM reports it as "ready"
+FORCE_FAILURE_ENDPOINTS = set(["inputs1.osdsecuritylogs.splunkcloud.com:9997"])

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,6 @@
+"""'CSV Analysis Python Script' settings. Configure these before running'"""
+
+REMOTE_LOG_AUTH = ("username", "password")
+
+REMOTE_LOG_FILE_NAME = "osd-network-verifier-logs.txt"
+REMOTE_LOG_REGEX_PATTERN = r"egressURL error\: ([\w\-\.]+\:\d+)\n"


### PR DESCRIPTION
This PR adds features for downloading and analyzing verifier logs stored on the server running the analysis cronjob. The analysis mainly consists of regex-ing for blocked egresses, errors, and clusters' HCP status. It also adds settings.py, for configuring these features.