### PR TITLE
Separating out HCP data

### DIFF
--- a/analyze_csv.py
+++ b/analyze_csv.py
@@ -1,26 +1,27 @@
 """Analyze a CSV produced by the verifier_log_cronjob.sh and print the results"""
 import argparse
 import csv
-import sys
+from multiprocessing import Manager
 
 from models import ClusterVerifierRecord, Outcome
 
+# Parse command line arguments
 arg_parser = argparse.ArgumentParser(
     description="Analyze CSVs produced by verifier_log_cronjob.sh and print the results"
 )
 arg_parser.add_argument(
     "csv_file",
-    type=argparse.FileType(encoding="utf-8"),
-    nargs=1,
+    type=argparse.FileType(),
     help="path to the CSV file under analysis",
 )
 arg_parser.add_argument(
     "--hcp",
     action=argparse.BooleanOptionalAction,
     help=(
-        "analyze ONLY data generated from HyperShift/HCP HostedClusters. "
-        "Conversely, --no-hcp excludes all HostedCluster data. Set "
-        "neither of these to analyze all data"
+        "analyze ONLY data generated from HyperShift/HCP HostedClusters. Conversely, "
+        "--no-hcp excludes all HostedCluster data. Set neither of these to analyze "
+        "all data. NOTE: setting either flag will cause an extra HTTP request per"
+        "cluster ID, likely slowing processing considerably"
     ),
 )
 arg_parser.add_argument(
@@ -35,17 +36,25 @@ arg_parser.add_argument(
     type=str,
     help="ignore data collected after ISO8601_DATETIME",
 )
+args = arg_parser.parse_args()
 
+# Read CSV and create a ClusterVerifierRecord (CVR) from each row
 cvrs = {}
-with open(sys.argv[1], newline="", encoding="utf-8") as f:
-    reader = csv.DictReader(f)
+with Manager() as manager:
+    # Use a "dict manager" for our HCP cache (futureproofing against multiprocessing)
+    hcp_cache = manager.dict()
+    # with open(args.csv_file, newline="", encoding="utf-8") as f:
+    reader = csv.DictReader(args.csv_file)
     for row in reader:
         cvr = ClusterVerifierRecord.from_dict(row)
-        try:
-            cvrs[cvr.cid] += cvr
-        except KeyError:
-            # First time we're seeing a CVR for this cluster ID; store it
-            cvrs[cvr.cid] = cvr
+        # Filter out HCPs according to presence of --(no-)hcp flag
+        if args.hcp is None or args.hcp == cvr.is_hostedcluster(cache=hcp_cache):
+            try:
+                cvrs[cvr.cid] += cvr
+            except KeyError:
+                # First time we're seeing a CVR for this cluster ID; store it
+                cvrs[cvr.cid] = cvr
+args.csv_file.close()
 
 
 print(f"Total deduplicated records: {len(cvrs)}")

--- a/analyze_csv.py
+++ b/analyze_csv.py
@@ -1,8 +1,40 @@
 """Analyze a CSV produced by the verifier_log_cronjob.sh and print the results"""
+import argparse
 import csv
 import sys
 
 from models import ClusterVerifierRecord, Outcome
+
+arg_parser = argparse.ArgumentParser(
+    description="Analyze CSVs produced by verifier_log_cronjob.sh and print the results"
+)
+arg_parser.add_argument(
+    "csv_file",
+    type=argparse.FileType(encoding="utf-8"),
+    nargs=1,
+    help="path to the CSV file under analysis",
+)
+arg_parser.add_argument(
+    "--hcp",
+    action=argparse.BooleanOptionalAction,
+    help=(
+        "analyze ONLY data generated from HyperShift/HCP HostedClusters. "
+        "Conversely, --no-hcp excludes all HostedCluster data. Set "
+        "neither of these to analyze all data"
+    ),
+)
+arg_parser.add_argument(
+    "--since",
+    metavar="ISO8601_DATETIME",
+    type=str,
+    help="ignore data collected before ISO8601_DATETIME",
+)
+arg_parser.add_argument(
+    "--until",
+    metavar="ISO8601_DATETIME",
+    type=str,
+    help="ignore data collected after ISO8601_DATETIME",
+)
 
 cvrs = {}
 with open(sys.argv[1], newline="", encoding="utf-8") as f:

--- a/models.py
+++ b/models.py
@@ -186,18 +186,35 @@ class ClusterVerifierRecord:
 
         return egress_failures
 
-    def is_hostedcluster(self) -> bool:
+    def is_hostedcluster(self, cache: dict[str, bool] = None) -> bool:
         """
         Parses the OCM description file stored in log_download_url and returns True if
-        this cluster is an HCP/HyperShift HostedCluster (i.e. "hypershift.enabled")
+        this cluster is an HCP/HyperShift HostedCluster (i.e. "hypershift.enabled").
+        May return None if OCM description file is unreadable/missing. Optionally,
+        pass a Manager.dict() object to enable cluster-ID-based caching.
         """
+        if cache is None:
+            cache = {}
         if self.__hostedcluster is None:
-            desc = requests.get(
-                self.log_download_url + "desc.json",
-                timeout=5,
-                auth=self.remote_log_auth,
-            ).json()
-            self.__hostedcluster = bool(desc["hypershift"]["enabled"])
+            try:
+                # Try fetching HCP status from cache
+                self.__hostedcluster = cache[self.cid]
+            except KeyError:
+                # HCP status not cached for this cluster ID
+                desc_req = requests.get(
+                    self.log_download_url + "desc.json",
+                    timeout=5,
+                    auth=self.remote_log_auth,
+                )
+                try:
+                    self.__hostedcluster = bool(
+                        desc_req.json()["hypershift"]["enabled"]
+                    )
+                    # Update cache
+                    cache[self.cid] = self.__hostedcluster
+                except requests.exceptions.JSONDecodeError:
+                    # Blank/malformed cluster description JSON. Allow default to None
+                    pass
         return self.__hostedcluster
 
     def __download_logs(self):


### PR DESCRIPTION
This PR adds the `--hcp` and `--no-hcp` flags, which include/exclude CSV rows relating to HCP clusters. Leaving the flag off means the script makes no attempt to discern HCP status (i.e., all rows are processed).