### PR TITLE
Use requests-cache instead of per-value manual caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ cython_debug/
 *.csv
 *.json
 *.sh
+*.sqlite
 results/
 oldtests/
 .netrc

--- a/models.py
+++ b/models.py
@@ -13,7 +13,7 @@ import settings
 from util import csv_bool_to_bool, is_nully_str, is_valid_url
 
 # Enable HTTP caching globally
-install_cache(".vla-http-cache", backend=("sqlite"), expire_after=NEVER_EXPIRE)
+install_cache(".vla-http-cache", backend="sqlite", expire_after=NEVER_EXPIRE)
 
 
 class OCMState(IntEnum):

--- a/models.py
+++ b/models.py
@@ -7,9 +7,13 @@ from typing import Optional
 
 import htmllistparse
 import requests
+from requests_cache import install_cache, NEVER_EXPIRE
 
 import settings
 from util import csv_bool_to_bool, is_nully_str, is_valid_url
+
+# Enable HTTP caching globally
+install_cache(".vla-http-cache", backend=("sqlite"), expire_after=NEVER_EXPIRE)
 
 
 class OCMState(IntEnum):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ htmllistparse==0.6.1
 requests==2.31.0
 beautifulsoup4==4.12.2
 html5lib==1.1
+requests-cache==1.1.0


### PR DESCRIPTION
Up until now, we've been caching select values fetched from remote log servers as needed. This PR replaces our ad-hoc approach with [requests-cache](https://github.com/requests-cache/requests-cache). We use this module's `install_cache()` function to enable HTTP caching globally (such that other imported modules like htmllistparse also get free caching). By default, HTTP requests are cached indefinitely in the present working directory in an SQLite database file named ".vla-http-cache"

In tests, this new approach reduced a 60-80 second operation down to 1-2 seconds on the second run. On the first run (i.e., with no cache), however, there is a significant time penalty.