### PR TITLE
Separating out internal customer data

### DIFF
--- a/analyze_csv.py
+++ b/analyze_csv.py
@@ -5,8 +5,6 @@ import sys
 from datetime import datetime, timezone
 from requests_cache import install_cache, NEVER_EXPIRE
 
-# pylint: disable=C0103
-
 # Enable HTTP caching globally before importing network-using modules
 install_cache(
     ".vla-http-cache",
@@ -14,7 +12,7 @@ install_cache(
     expire_after=NEVER_EXPIRE,
     allowable_methods=["GET"],
 )
-# pylint: disable=wrong-import-position
+# pylint: disable=wrong-import-position, C0103
 from models import ClusterVerifierRecord, Outcome
 from util import OCMClient, is_internal_customer
 

--- a/analyze_csv.py
+++ b/analyze_csv.py
@@ -5,6 +5,8 @@ import sys
 from datetime import datetime, timezone
 from requests_cache import install_cache, NEVER_EXPIRE
 
+# pylint: disable=C0103
+
 # Enable HTTP caching globally before importing network-using modules
 install_cache(
     ".vla-http-cache",
@@ -94,6 +96,7 @@ if args.internal_cx is not None:
     filtered_cvrs = []
     org_id_cache = {}  # Maps org IDs to bools (True == int. cx.)
     ocm_client = OCMClient()
+    cvrs_thrown_away = 0
     # Iterate over a list-copy of the cvrs dict (so that we can delete stuff)
     for cid, cvr in list(cvrs.items()):
         try:
@@ -109,10 +112,13 @@ if args.internal_cx is not None:
             if not cvr_is_int_cx == args.internal_cx:
                 del cvrs[cid]
         except ValueError as exc:
-            print(
-                f"WARN: unable to determine if {cid} is internal; throwing away. Details: {exc}"
-            )
+            cvrs_thrown_away += 1
             del cvrs[cid]
+    if cvrs_thrown_away > 0:
+        print(
+            f"WARN: discarded data from {cvrs_thrown_away} clusters due to inability "
+            "to determine owner"
+        )
 
 
 print(f"Total Clusters,{len(cvrs)},")

--- a/models.py
+++ b/models.py
@@ -111,7 +111,10 @@ class ClusterVerifierRecord:
         self.__logs = {}
 
         # hostedcluster will keep track of this cluster's hypershift status
-        self.__hostedcluster = None
+        self._hostedcluster = None
+
+        # organization_id will keep track of this cluster owners's OCM org ID
+        self._organization_id = None
 
         # reached_states keeps track of all states in which we've seen this cluster
         self.reached_states = set()
@@ -238,7 +241,13 @@ class ClusterVerifierRecord:
             lesser_cvr.timestamp = greater_cvr.timestamp
             return lesser_cvr
 
+        # Transfer some attributes from least to greatest
         greater_cvr.reached_states.update(lesser_cvr.reached_states)
+        if greater_cvr._hostedcluster is None:
+            greater_cvr._hostedcluster = lesser_cvr._hostedcluster
+        if greater_cvr._organization_id is None:
+            greater_cvr._organization_id = lesser_cvr._organization_id
+
         return greater_cvr
 
     def __gt__(self, other):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests==2.31.0
 beautifulsoup4==4.12.2
 html5lib==1.1
 requests-cache==1.1.0
+requests-oauthlib==1.3.1

--- a/settings.py
+++ b/settings.py
@@ -21,6 +21,10 @@ REMOTE_LOG_ERROR_REGEX_PATTERN = (
     r"|error performing [\w\d]*:[\w\d]*).*[\n$]"
 )
 
+# Regular expression to use for identifying internal customers (no capturing groups)
+# Will be evaluated with the IGNORECASE flag
+INTERNAL_CUSTOMER_REGEX_PATTERN = r"foo|bar"
+
 # Set of egress endpoints that, if seen, should convert a false positive into a true
 # positive. For example, we can assume that a cluster that blocks its Splunk forwarding
 # URL will be considered "failed" even if OCM reports it as "ready"

--- a/util.py
+++ b/util.py
@@ -1,5 +1,10 @@
 """Helper/utility functions"""
+import json
+import os
 import re
+
+from requests_oauthlib import OAuth2Session
+from oauthlib.oauth2 import TokenExpiredError
 
 
 def csv_bool_to_bool(csv_bool_str):
@@ -33,3 +38,46 @@ def is_valid_url(url):
         re.IGNORECASE,
     )
     return url is not None and regex.search(url)
+
+
+class OCMClient:
+    """
+    Read-only OCM API client. Loads credentials from file specified by environmental
+    variable OCM_CONFIG
+    """
+
+    def __init__(self):
+        with open(os.getenv("OCM_CONFIG"), encoding="utf-8") as ocm_config_file:
+            ocm_config = json.load(ocm_config_file)
+        # Build initial (expired) token
+        self._token = {
+            "access_token": ocm_config["access_token"],
+            "refresh_token": ocm_config["refresh_token"],
+            "token_type": "Bearer",
+            "expires_at": 10,
+        }
+        self._client_id = ocm_config["client_id"]
+        self._refresh_url = ocm_config["token_url"]
+        self._base_url = ocm_config["url"]
+
+        # Build initial client
+        self._session = OAuth2Session(
+            client_id=self._client_id,
+            token=self._token,
+        )
+
+    def _refresh_token(self):
+        """Requests a new Bearer token and updates self._token"""
+        self._token = self._session.refresh_token(
+            token_url=self._refresh_url, client_id=self._client_id
+        )
+        self._session = OAuth2Session(client_id=self._client_id, token=self._token)
+
+    def get(self, path, **kwargs):
+        """Wrapper around requests module's get()"""
+        try:
+            return self._session.get(self._base_url + path, **kwargs)
+        except TokenExpiredError:
+            # Refresh token and try again
+            self._refresh_token()
+            return self._session.get(self._base_url + path, **kwargs)

--- a/util.py
+++ b/util.py
@@ -6,38 +6,7 @@ import re
 from requests_oauthlib import OAuth2Session
 from oauthlib.oauth2 import TokenExpiredError
 
-
-def csv_bool_to_bool(csv_bool_str):
-    """Converts an Excel/CSV-style Boolean string (TRUE/FALSE) into a Python bool"""
-    if csv_bool_str.strip().lower() == "true":
-        return True
-    if csv_bool_str.strip().lower() == "false":
-        return False
-    return None
-
-
-def is_nully_str(s):
-    """
-    Returns True if s is None, an empty or whitespace-filled string, or some variation of "NULL"
-    """
-    if s is None:
-        return True
-    s_strip = s.lower().strip()
-    return s_strip in ["", "null"]
-
-
-def is_valid_url(url):
-    """Returns true if input is a valid HTTP(S) URL"""
-    regex = re.compile(
-        r"^https?://"  # http:// or https://
-        r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+[A-Z]{2,6}\.?|"  # domain...
-        r"localhost|"  # localhost...
-        r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"  # ...or ip
-        r"(?::\d+)?"  # optional port
-        r"(?:/?|[/?]\S+)$",
-        re.IGNORECASE,
-    )
-    return url is not None and regex.search(url)
+from settings import INTERNAL_CUSTOMER_REGEX_PATTERN
 
 
 class OCMClient:
@@ -81,3 +50,44 @@ class OCMClient:
             # Refresh token and try again
             self._refresh_token()
             return self._session.get(self._base_url + path, **kwargs)
+
+
+def csv_bool_to_bool(csv_bool_str):
+    """Converts an Excel/CSV-style Boolean string (TRUE/FALSE) into a Python bool"""
+    if csv_bool_str.strip().lower() == "true":
+        return True
+    if csv_bool_str.strip().lower() == "false":
+        return False
+    return None
+
+
+def is_nully_str(s):
+    """
+    Returns True if s is None, an empty or whitespace-filled string, or some variation of "NULL"
+    """
+    if s is None:
+        return True
+    s_strip = s.lower().strip()
+    return s_strip in ["", "null"]
+
+
+def is_valid_url(url):
+    """Returns true if input is a valid HTTP(S) URL"""
+    regex = re.compile(
+        r"^https?://"  # http:// or https://
+        r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+[A-Z]{2,6}\.?|"  # domain...
+        r"localhost|"  # localhost...
+        r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"  # ...or ip
+        r"(?::\d+)?"  # optional port
+        r"(?:/?|[/?]\S+)$",
+        re.IGNORECASE,
+    )
+    return bool(url is not None and regex.search(url))
+
+
+def is_internal_customer(ocm_client: OCMClient, organization_id: str) -> bool:
+    """Queries OCM and returns True if an organization ID looks like an internal cluster"""
+    org_resp = ocm_client.get("/api/accounts_mgmt/v1/organizations/" + organization_id)
+    org_name = org_resp.json()["name"]
+    regex = re.compile(INTERNAL_CUSTOMER_REGEX_PATTERN, re.IGNORECASE)
+    return bool(organization_id is not None and regex.search(org_name))


### PR DESCRIPTION
This PR adds the --internal-cx and --no-internal-cx flags, which include/exclude CSV rows relating to clusters owned by internal customers. Leaving the flag off means the script makes no attempt to discern cluster owner (i.e., all rows are processed).

Because OCM's cluster descriptions do not include customer-identifying data (other than a SubscriptionLink), this PR adds a read-only OCMClient that loads OAuth credentials from the file path stored in the env-var `OCM_CONFIG` (same as `ocm` binary). This allows us to ask OCM which organization ID owns a particular subscription, and what company name is associated with a given organization ID. A new variable in settings.py (`INTERNAL_CUSTOMER_REGEX_PATTERN`) allows the user to provide a regex against which company names can be matched to determine internal vs. external status. Because all of this requires several more HTTP requests to OCM, this PR also makes more aggressive use of the `requests_cache` module.